### PR TITLE
Properly handle options passed into commands

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -2,15 +2,16 @@ const { getImageConfig, getScreenshotConfig } = require('../src/config');
 
 describe('config', () => {
   it('getImageConfig', () => {
-    const config = {
+    const config = { taskOptions: {
       imageConfig: {
         threshold: 0.5,
-        bar: 'should be ignored',
+        bar: 'should be included',
       },
       foo: 'should be ignored',
-    };
+    }};
 
     expect(getImageConfig(config)).toEqual({
+      bar: 'should be included',
       createDiffImage: true,
       resizeDevicePixelRatio: true,
       threshold: 0.5,
@@ -19,15 +20,16 @@ describe('config', () => {
   });
 
   it('getScreenshotConfig', () => {
-    const config = {
+    const config = { taskOptions: {
       log: true,
       clip: {
         x: 0,
         y: 0,
         height: 100,
         width: 100,
-      }
-    };
+      },
+      onBeforeScreenshot: 'some function'
+    }};
 
     expect(getScreenshotConfig(config)).toEqual({
       blackout: ['.snapshot-diff'],
@@ -40,6 +42,7 @@ describe('config', () => {
       },
       disableTimersAndAnimations: true,
       log: true,
+      onBeforeScreenshot: 'some function',
       scale: false,
       timeout: 30000,
     });

--- a/commands.js
+++ b/commands.js
@@ -18,7 +18,7 @@ function addCommand(commandName, method) {
       return commandSubject;
     }
 
-    const options = merge({}, cloneDeep(getConfig()), taskOptions);
+    const options = merge({}, cloneDeep(getConfig()), taskOptions, { taskOptions });
     return cy.wrap(commandSubject, NO_LOG)
       .then((subject) => method(subject, options));
   });

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const { merge, cloneDeep, clone } = require('lodash');
+const { merge, cloneDeep, clone, get } = require('lodash');
 const { TYPE_JSON } = require('./dataTypes');
 
 function createToken() {
@@ -67,29 +67,21 @@ function getConfig() {
 }
 
 function getImageConfig(options = {}) {
-  return Object.keys(DEFAULT_IMAGE_CONFIG)
-    .filter((key) => options.imageConfig && options.imageConfig[key] !== undefined)
-    .reduce(
-      (imageConfig, key) => {
-        imageConfig[key] = options.imageConfig[key];
-        return imageConfig;
-      },
-      merge({}, DEFAULT_IMAGE_CONFIG, getConfig().imageConfig)
-    );
+  return merge(
+    {},
+    DEFAULT_IMAGE_CONFIG, // plugin defaults
+    options.imageConfig, // external config (cypress.json, command line args)
+    get(options.taskOptions, 'imageConfig') // options passed into the command
+  );
 }
 
-
 function getScreenshotConfig(options = {}) {
-  const screenshotConfig = Object.keys(DEFAULT_SCREENSHOT_CONFIG)
-    .filter((key) => options && options[key] !== undefined)
-    .reduce(
-      (imageConfig, key) => {
-        imageConfig[key] = options[key];
-        return imageConfig;
-      },
-      merge({}, DEFAULT_SCREENSHOT_CONFIG, getConfig().screenshotConfig)
-    );
-
+  const screenshotConfig = merge(
+    {},
+    DEFAULT_SCREENSHOT_CONFIG, // plugin defaults
+    options.screenshotConfig, // external config (cypress.json, command line args)
+    options.taskOptions // options passed into the command
+  );
   screenshotConfig.blackout = (screenshotConfig.blackout || []);
   screenshotConfig.blackout.push('.snapshot-diff');
   return screenshotConfig;


### PR DESCRIPTION
Bug in the original code.

### Repro

In a test, call 

```
cy.toMatchImageSnapshot({ onBeforeScreenshot: () => console.log('boop') })
```

When that test runs, you won't see any console output. This is because there is no defined default value for `onBeforeScreenshot` in the plugin. The logic for squashing the plugin's defaults, the cypress.json options, and your provided command options is wrong. It loops over the keys of the defaults, meaning your provided option for that key is ignored.

Checkout this branch and do the same above, you will now see the output in the console :+1: